### PR TITLE
Small readme issues / suggestions fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1084,6 +1084,8 @@ IF YOU DECIDE TO MINT THE REAL NFT:
 *[⌨️ (4:12:20) | Setup](https://youtu.be/umepbfKp5rI?t=15140)*
 ## Sending ETH through a function
 *[⌨️ (4:14:00) | Sending ETH through a function](https://youtu.be/umepbfKp5rI?t=15240)*
+- [Ethereum Unit Converter](https://eth-converter.com/)
+  
 - [Fields in a Transaction](https://ethereum.org/en/developers/docs/transactions/)
 - [More on v,r,s](https://ethereum.stackexchange.com/questions/15766/what-does-v-r-s-in-eth-gettransactionbyhash-mean)
 - [payable](https://solidity-by-example.org/payable)

--- a/README.md
+++ b/README.md
@@ -1379,6 +1379,7 @@ ANYWHERE written in plain text
 *[⌨️ (4:40) | Testing Introduction ](https://youtu.be/sas02qSFZ74?t=280)*
 ## Setup Continued
 *[⌨️ (6:14) | Setup Continued ](https://youtu.be/sas02qSFZ74?t=374)*
+- [Chainlink Brownie Contracts Github Repo](https://github.com/smartcontractkit/chainlink-brownie-contracts)
 - [Dependencies](https://book.getfoundry.sh/projects/dependencies)
 - [remappings](https://book.getfoundry.sh/reference/forge/forge-remappings)
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Welcome to the repository for the Blockchain Developer, Smart Contract, & Solidi
     <li><a href="#private-key-rant-i">Private Key Rant I</a></li>
     <li><a href="#deploying-to-a-local-chain-iii-forge-script">Deploying to a local chain III (Forge Script)</a></li>
     <li><a href="#what-is-a-transaction-but-actually">What is a transaction (But actually)</a></li>
-    <li><a href="#private-key-r-ant-ii">Private Key R ant II</a></li>
+    <li><a href="#private-key-rant-ii">Private Key R ant II</a></li>
     <li><a href="#can-you-encrypt-a-private-key---a-keystore-in-foundry-yet">Can you Encrypt a Private Key -&gt; a keystore in foundry yet??</a></li>
     <li><a href="#thirdweb-deploy">ThirdWeb Deploy</a></li>
     <li><a href="#private-key-rant-summary">Private Key Rant Summary:</a></li>

--- a/README.md
+++ b/README.md
@@ -1381,7 +1381,8 @@ ANYWHERE written in plain text
 *[⌨️ (6:14) | Setup Continued ](https://youtu.be/sas02qSFZ74?t=374)*
 - [Chainlink Brownie Contracts Github Repo](https://github.com/smartcontractkit/chainlink-brownie-contracts)
   ```bash
-  forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit```
+  forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit
+  ```
 - [Dependencies](https://book.getfoundry.sh/projects/dependencies)
 - [remappings](https://book.getfoundry.sh/reference/forge/forge-remappings)
 

--- a/README.md
+++ b/README.md
@@ -1110,6 +1110,7 @@ IF YOU DECIDE TO MINT THE REAL NFT:
 *[⌨️ (4:36:22) | Quick recap I](https://youtu.be/umepbfKp5rI?t=16582)*
 ## Interfaces
 *[⌨️ (4:37:08) | Interfaces](https://youtu.be/umepbfKp5rI?t=16628)*
+- For reference - [ChainLink Interface's Repo](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol)
 ## AI Help III
 *[⌨️ (4:43:31) | AI Help III](https://youtu.be/umepbfKp5rI?t=17011)*
 ## Importing from NPM / GitHub

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Welcome to the repository for the Blockchain Developer, Smart Contract, & Solidi
     <li><a href="#private-key-rant-i">Private Key Rant I</a></li>
     <li><a href="#deploying-to-a-local-chain-iii-forge-script">Deploying to a local chain III (Forge Script)</a></li>
     <li><a href="#what-is-a-transaction-but-actually">What is a transaction (But actually)</a></li>
-    <li><a href="#private-key-rant-ii">Private Key R ant II</a></li>
+    <li><a href="#private-key-rant-ii">Private Key Rant II</a></li>
     <li><a href="#can-you-encrypt-a-private-key---a-keystore-in-foundry-yet">Can you Encrypt a Private Key -&gt; a keystore in foundry yet??</a></li>
     <li><a href="#thirdweb-deploy">ThirdWeb Deploy</a></li>
     <li><a href="#private-key-rant-summary">Private Key Rant Summary:</a></li>

--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,8 @@ ANYWHERE written in plain text
 ## Setup Continued
 *[⌨️ (6:14) | Setup Continued ](https://youtu.be/sas02qSFZ74?t=374)*
 - [Chainlink Brownie Contracts Github Repo](https://github.com/smartcontractkit/chainlink-brownie-contracts)
+  ```bash
+  forge install smartcontractkit/chainlink-brownie-contracts@0.6.1 --no-commit```
 - [Dependencies](https://book.getfoundry.sh/projects/dependencies)
 - [remappings](https://book.getfoundry.sh/reference/forge/forge-remappings)
 


### PR DESCRIPTION
In chapter 6.15, the word "rant" had a space in it ["r ant"], and caused the link to break.

Fixed the text and the link inside the readme.