### PR TITLE
Fix lesson 0 name and link in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Welcome to the repository for the Blockchain Developer, Smart Contract, & Solidi
 </ol>
 </details>
 <details>
-<summary> <a href="#lesson-0-the-edge-of-the-rabbit-hole">Lesson 0: The Edge of the Rabbit Hole</a></summary>
+<summary> <a href="#lesson-0-welcome-to-the-course">Lesson 0: Welcome to the Course!</a></summary>
 <ol>
   <li>
   <a href="#welcome-to-the-course">Welcome to the course! </a>


### PR DESCRIPTION
Change the name of the "Lesson 0" in the README.md Table of Contents to correspond with the name of the lesson mentioned in the [subsequent section](https://github.com/Cyfrin/foundry-full-course-f23#lesson-0-welcome-to-the-course).