### PR TITLE
Update chronological-updates.md

### DIFF
--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -47,7 +47,7 @@ What it should be:
 # Lesson 12
 
 In the latest version of openzeppelin/openzeppelin-contracts `ERC20Mock.sol` file has been updated with **0** constructor parameters.
-You should use `forge install openzeppelin/openzeppelin-contracts@4.8.3 --no-commit` command to download the appropriate version synced with the video.
+You should use `forge install openzeppelin/openzeppelin-contracts@v4.8.3 --no-commit` command to download the appropriate version synced with the video.
 
 # Lesson 13
 

--- a/chronological-updates.md
+++ b/chronological-updates.md
@@ -46,6 +46,9 @@ What it should be:
 
 # Lesson 12
 
+In the latest version of openzeppelin/openzeppelin-contracts `ERC20Mock.sol` file has been updated with **0** constructor parameters.
+You should use `forge install openzeppelin/openzeppelin-contracts@4.8.3 --no-commit` command to download the appropriate version synced with the video.
+
 # Lesson 13
 
 # Lesson 14


### PR DESCRIPTION
In Lesson 12 `forge install openzeppelin/openzeppelin-contracts --no-commit` command no longer is in sync with the video because they have updated the `ERC20Mock.sol` file.