### PR TITLE
Remove Chainlink Faucet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,8 +809,8 @@ Welcome to the repository for the Blockchain Developer, Smart Contract, & Solidi
 - Recommended DevOps: [foundry-devops](https://github.com/Cyfrin/foundry-devops)
 
 # [Testnet Faucets](https://faucets.chain.link)
-- Main Faucet:<a href="https://faucets.chain.link" target="_blank" > https://faucets.chain.link</a>
-- Backup Faucet:<a href="https://sepoliafaucet.com/" target="_blank"> https://sepoliafaucet.com/</a>
+- Main Faucet:<a href="https://sepoliafaucet.com/" target="_blank"> https://sepoliafaucet.com/</a>
+- Backup Faucet:<a href="https://www.infura.io/faucet/sepolia" target="_blank" > https://www.infura.io/faucet/sepolia</a>
 
 > ⚠️ All code associated with this course is for demo purposes only. They have not been audited and should not be considered production ready. Please use at your own risk. 
 


### PR DESCRIPTION
Chainlink no longer offers the option to send ETH on the Sepolia Network, only Link. I changed the Alchemy faucet to main, and added Infura faucet as a backup.

<img width="1231" alt="Screenshot 2023-08-02 at 2 12 32 PM" src="https://github.com/Cyfrin/foundry-full-course-f23/assets/44731696/86936515-bd0a-4ec9-9aeb-a8bc32fcf4c2">
