### PR TITLE
Update outdated path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ _[⌨️ (4:36:22) | Quick recap I](https://youtu.be/umepbfKp5rI?t=16582)_
 
 _[⌨️ (4:37:08) | Interfaces](https://youtu.be/umepbfKp5rI?t=16628)_
 
-- For reference - [ChainLink Interface's Repo](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol)
+- For reference - [ChainLink Interface's Repo](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol)
 
 ## AI Help III
 


### PR DESCRIPTION
The Reference Link to the Chainlink Interface's Repo "AggregatorV3Interface.sol" is outdated as Chainlink changed the path.

Old Link returns a 404 Error -> https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol

The Link in the README.md File was changed to the updated one, to avoid further confusion -> https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/shared/interfaces/AggregatorV3Interface.sol